### PR TITLE
Fix tests, increase coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,15 +1,19 @@
-name: Go tests
 on: [ push ]
+name: Go tests
 jobs:
   Build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.16.x, 1.17.x, 1.18.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
 
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: ${{ matrix.go-version }}
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -48,4 +48,3 @@ jobs:
           flags: mysql_tests
           fail_ci_if_error: true
 
-

--- a/apply.go
+++ b/apply.go
@@ -234,6 +234,9 @@ func (d *Database) doOneMigration(ctx context.Context, m Migration) (bool, error
 			"name":     m.Base().Name.Name,
 		})
 	}
+	if err := d.driver.IsMigrationSupported(d, d.log, m); err != nil {
+		return false, err
+	}
 	if m.Base().skipIf != nil {
 		skip, err := m.Base().skipIf()
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-sql-driver/mysql v1.6.0
-	github.com/lib/pq v1.10.4
+	github.com/lib/pq v1.10.5
 	github.com/muir/sqltoken v0.0.4
 	github.com/muir/testinglogur v0.0.1
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/muir/libschema
 go 1.16
 
 require (
-	github.com/Masterminds/squirrel v1.5.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/lib/pq v1.10.4
 	github.com/muir/sqltoken v0.0.4

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/muir/libschema
 go 1.16
 
 require (
+	github.com/Masterminds/squirrel v1.5.2 // indirect
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/lib/pq v1.10.4
 	github.com/muir/sqltoken v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,9 @@
-github.com/Masterminds/squirrel v1.5.2 h1:UiOEi2ZX4RCSkpiNDQN5kro/XIBpSRk9iTqdIRPzUXE=
-github.com/Masterminds/squirrel v1.5.2/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/alvaroloes/enumer v1.1.2/go.mod h1:FxrjvuXoDAx9isTJrv4c+T410zFi0DtXIT0m65DJ+Wo=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
-github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
-github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
-github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
-github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lib/pq v1.10.4 h1:SO9z7FRPzA03QhHKJrH5BXA6HU1rS4V2nIVrrNC1iYk=
 github.com/lib/pq v1.10.4/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/muir/sqltoken v0.0.4 h1:SioNnG90ZYXmlfnPaUxUdNC1dFkhKL64pDeS+wXZ8k8=
@@ -22,7 +16,6 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
-github.com/lib/pq v1.10.4 h1:SO9z7FRPzA03QhHKJrH5BXA6HU1rS4V2nIVrrNC1iYk=
-github.com/lib/pq v1.10.4/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.10.5 h1:J+gdV2cUmX7ZqL2B0lFcW0m+egaHC2V3lpO8nWxyYiQ=
+github.com/lib/pq v1.10.5/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/muir/sqltoken v0.0.4 h1:SioNnG90ZYXmlfnPaUxUdNC1dFkhKL64pDeS+wXZ8k8=
 github.com/muir/sqltoken v0.0.4/go.mod h1:6hPsZxszMpYyNf12og4f4VShFo/Qipz6Of0cn5KGAAU=
 github.com/muir/testinglogur v0.0.1 h1:k0lztrKzttiH5Pjtzj7S4tXXXBgUaxqTtVKXK4ndiI8=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,15 @@
+github.com/Masterminds/squirrel v1.5.2 h1:UiOEi2ZX4RCSkpiNDQN5kro/XIBpSRk9iTqdIRPzUXE=
+github.com/Masterminds/squirrel v1.5.2/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/alvaroloes/enumer v1.1.2/go.mod h1:FxrjvuXoDAx9isTJrv4c+T410zFi0DtXIT0m65DJ+Wo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
+github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
+github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
+github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lib/pq v1.10.4 h1:SO9z7FRPzA03QhHKJrH5BXA6HU1rS4V2nIVrrNC1iYk=
 github.com/lib/pq v1.10.4/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/muir/sqltoken v0.0.4 h1:SioNnG90ZYXmlfnPaUxUdNC1dFkhKL64pDeS+wXZ8k8=
@@ -15,6 +22,7 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/lsmysql/mysql.go
+++ b/lsmysql/mysql.go
@@ -24,9 +24,10 @@ import (
 // to determine if the transaction succeeded or failed.  Such transactions will be retried.
 // For this reason, it is reccomend that DDL commands be written such that they are idempotent.
 type MySQL struct {
-	lockTx  *sql.Tx
-	lockStr string
-	db      *sql.DB
+	lockTx       *sql.Tx
+	lockStr      string
+	db           *sql.DB
+	databaseName string // used in skip.go only
 }
 
 // New creates a libschema.Database with a mysql driver built in.

--- a/lsmysql/skip.go
+++ b/lsmysql/skip.go
@@ -103,7 +103,10 @@ func (p *MySQL) GetTableConstraint(table, constraintName string) (string, bool, 
 }
 
 // DatabaseName returns the name of the current database (aka schema for MySQL).
-// A call to UseDatabase() overrides all future calls to DatabaseName()
+// A call to UseDatabase() overrides all future calls to DatabaseName().  If the
+// MySQL object was created from a libschema.Schema that had SchemaOverride set
+// then this will return whatever that value was.  It is reccomened that
+// UseDatabase() be called to make sure that the right database is returned.
 func (m *MySQL) DatabaseName() (string, error) {
 	if m.databaseName != "" {
 		return m.databaseName, nil
@@ -115,7 +118,8 @@ func (m *MySQL) DatabaseName() (string, error) {
 
 // UseDatabase() overrides the default database for DatabaseName(), ColumnDefault(), HasPrimaryKey(),
 // HasTableIndex(), DoesColumnExist(), and GetTableConstraint().
-// If name is empty then the override is removed.
+// If name is empty then the override is removed and the database will be queried from
+// the mysql server.  Due to connection pooling in Go, that's a bad idea.
 func (m *MySQL) UseDatabase(name string) {
 	m.databaseName = name
 }

--- a/lsmysql/skip_test.go
+++ b/lsmysql/skip_test.go
@@ -1,0 +1,133 @@
+package lsmysql_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/muir/libschema"
+	"github.com/muir/libschema/lsmysql"
+	"github.com/muir/libschema/lstesting"
+	"github.com/muir/testinglogur"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkipFunctions(t *testing.T) {
+	dsn := os.Getenv("LIBSCHEMA_MYSQL_TEST_DSN")
+	if dsn == "" {
+		t.Skip("Set $LIBSCHEMA_MYSQL_TEST_DSN to test libschema/lsmysql")
+	}
+
+	options, cleanup := lstesting.FakeSchema(t, "")
+	options.DebugLogging = true
+	s := libschema.New(context.Background(), options)
+
+	t.Log("DSN=", dsn)
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err, "open database")
+	defer db.Close()
+	_ = cleanup
+	// defer cleanup(db)
+
+	dbase, m, err := lsmysql.New(testinglogur.Get(t), "test", s, db)
+	require.NoError(t, err, "libschema NewDatabase")
+
+	dbase.Migrations("T",
+		lsmysql.Script("setup1", `
+			CREATE TABLE IF NOT EXISTS users (
+				id	varchar(255),
+				level	integer DEFAULT 37,
+				PRIMARY KEY (id)
+			) ENGINE=InnoDB`),
+		lsmysql.Script("setup2", `
+			CREATE TABLE IF NOT EXISTS accounts (
+				id	varchar(255)
+			) ENGINE=InnoDB`),
+		lsmysql.Script("setup3", `
+			ALTER TABLE users
+				ADD CONSTRAINT hi_level 
+					CHECK (level > 10) ENFORCED`,
+			libschema.SkipIf(func() (bool, error) {
+				t, _, err := m.GetTableConstraint("users", "hi_level")
+				return t != "", err
+			})),
+		lsmysql.Script("setup4", `
+			CREATE INDEX level_idx ON users(level);`,
+			libschema.SkipIf(func() (bool, error) {
+				b, err := m.TableHasIndex("users", "level_idx")
+				return b, err
+			})),
+	)
+
+	err = s.Migrate(context.Background())
+	assert.NoError(t, err)
+
+	dbName, err := m.DatabaseName()
+	if assert.NoError(t, err, "database name") {
+		config, err := mysql.ParseDSN(dsn)
+		if assert.NoError(t, err, "parse dsn") {
+			assert.Equal(t, config.DBName, dbName, "database name")
+		}
+	}
+
+	m.UseDatabase(options.SchemaOverride)
+
+	dbNameOverride, err := m.DatabaseName()
+	if assert.NoError(t, err, "override database name") {
+		assert.Equal(t, options.SchemaOverride, dbNameOverride, "override database name")
+	}
+
+	hasPK, err := m.HasPrimaryKey("users")
+	if assert.NoError(t, err, "users has pk") {
+		assert.True(t, hasPK, "users has pk")
+	}
+	hasPK, err = m.HasPrimaryKey("accounts")
+	if assert.NoError(t, err, "accounts has pk") {
+		assert.False(t, hasPK, "accounts has pk")
+	}
+	dflt, err := m.ColumnDefault("users", "id")
+	if assert.NoError(t, err, "user id default") {
+		assert.Nil(t, dflt, "user id default")
+	}
+	dflt, err = m.ColumnDefault("users", "level")
+	if assert.NoError(t, err, "user level default") {
+		if assert.NotNil(t, dflt, "user level default") {
+			assert.Equal(t, "37", *dflt, "user id default")
+		}
+	}
+	exists, err := m.DoesColumnExist("users", "foo")
+	if assert.NoError(t, err, "users has foo") {
+		assert.False(t, exists, "users has foo")
+	}
+	exists, err = m.DoesColumnExist("users", "level")
+	if assert.NoError(t, err, "users has level") {
+		assert.True(t, exists, "users has level")
+	}
+	typ, enf, err := m.GetTableConstraint("users", "hi_level")
+	if assert.NoError(t, err, "users hi_level constraint") {
+		assert.Equal(t, "CHECK", typ, "users hi_level constraint")
+		assert.True(t, enf, "users hi_level constraint")
+	}
+
+	exists, err = m.TableHasIndex("users", "level_idx")
+	if assert.NoError(t, err, "has index users.level_idx") {
+		assert.True(t, exists, "has users.level_idx")
+	}
+	exists, err = m.TableHasIndex("foobar", "level_idx")
+	if assert.NoError(t, err, "has foobar.level_idx") {
+		assert.False(t, exists, "has foobar.level_idx")
+	}
+	exists, err = m.TableHasIndex("users", "foo_idx")
+	if assert.NoError(t, err, "has users.foo_idx") {
+		assert.False(t, exists, "has users.foo_idx")
+	}
+
+	m.UseDatabase("")
+	dbNameRestored, err := m.DatabaseName()
+	if assert.NoError(t, err, "original database name") {
+		assert.Equal(t, dbName, dbNameRestored, "restored database name")
+	}
+}

--- a/lsmysql/skip_test.go
+++ b/lsmysql/skip_test.go
@@ -139,6 +139,6 @@ func TestSkipFunctions(t *testing.T) {
 	m.UseDatabase("")
 	dbNameReRestored, err := m.DatabaseName()
 	if assert.NoError(t, err, "original database name #2") {
-		assert.Equal(t, dbNameRestored, dbNameReRestored, "un-override")
+		assert.NotEqual(t, "override", dbNameReRestored, "un-override")
 	}
 }

--- a/lsmysql/skip_test.go
+++ b/lsmysql/skip_test.go
@@ -130,7 +130,15 @@ func TestSkipFunctions(t *testing.T) {
 
 	m.UseDatabase("")
 	dbNameRestored, err := m.DatabaseName()
-	if assert.NoError(t, err, "original database name") {
-		assert.Equal(t, dbName, dbNameRestored, "restored database name")
+	assert.NoError(t, err, "original database name")
+	m.UseDatabase("override")
+	dbOverride, err := m.DatabaseName()
+	if assert.NoError(t, err, "database name override") {
+		assert.Equal(t, "override", dbOverride, "override")
+	}
+	m.UseDatabase("")
+	dbNameReRestored, err := m.DatabaseName()
+	if assert.NoError(t, err, "original database name #2") {
+		assert.Equal(t, dbNameRestored, dbNameReRestored, "un-override")
 	}
 }

--- a/lspostgres/postgres_test.go
+++ b/lspostgres/postgres_test.go
@@ -15,6 +15,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+/*
+
+PostgreSQL supports schemas so testing can be done with a user that is limited
+to a single database.
+
+export PGPASSWORD=postgres
+docker run --name postgres -p 5432:5432 -e POSTGRES_PASSWORD="$PGPASSWORD" --restart=always -d postgres:latest
+
+psql -h localhost -p 5432 --user postgres <<END
+CREATE DATABASE lstesting;
+CREATE USER lstestuser WITH NOCREATEDB PASSWORD 'lstestpass';
+GRANT ALL PRIVILEGES ON DATABASE lstesting TO lstestuser;
+END
+
+LIBSCHEMA_POSTGRES_TEST_DSN="postgresql://lstestuser:lstestpass@localhost:5432/lstesting?sslmode=disable"
+
+*/
+
 func TestPostgresMigrations(t *testing.T) {
 	dsn := os.Getenv("LIBSCHEMA_POSTGRES_TEST_DSN")
 	if dsn == "" {

--- a/lspostgres/postgres_test.go
+++ b/lspostgres/postgres_test.go
@@ -58,55 +58,70 @@ func TestPostgresMigrations(t *testing.T) {
 		}
 	}
 	options.DebugLogging = true
-	s := libschema.New(context.Background(), options)
 
 	db, err := sql.Open("postgres", dsn)
 	require.NoError(t, err, "open database")
 	defer db.Close()
 	defer cleanup(db)
 
+	s := libschema.New(context.Background(), options)
 	dbase, err := lspostgres.New(testinglogur.Get(t), "test", s, db)
 	require.NoError(t, err, "libschema NewDatabase")
 
-	dbase.Migrations("L1",
-		lspostgres.Generate("T1", func(_ context.Context, _ libschema.MyLogger, _ *sql.Tx) string {
-			actions = append(actions, "MIGRATE: L1.T1")
-			return `CREATE TABLE T1 (id text)`
-		}),
-		lspostgres.Computed("T2", func(_ context.Context, _ libschema.MyLogger, tx *sql.Tx) error {
-			actions = append(actions, "MIGRATE: L1.T2")
-			_, err := tx.Exec(`
+	defineMigrations := func(dbase *libschema.Database, extra bool) {
+		l1migrations := []libschema.Migration{
+			lspostgres.Generate("T1", func(_ context.Context, _ libschema.MyLogger, _ *sql.Tx) string {
+				actions = append(actions, "MIGRATE: L1.T1")
+				return `CREATE TABLE T1 (id text)`
+			}),
+			lspostgres.Computed("T2", func(_ context.Context, _ libschema.MyLogger, tx *sql.Tx) error {
+				actions = append(actions, "MIGRATE: L1.T2")
+				_, err := tx.Exec(`
 				INSERT INTO T1 (id) VALUES ('T2');
 				INSERT INTO T3 (id) VALUES ('T2');
 				CREATE TABLE T2 (id text)`)
-			return err
-		}, libschema.After("L2", "T3")),
-		lspostgres.Generate("PT1", func(_ context.Context, _ libschema.MyLogger, _ *sql.Tx) string {
-			actions = append(actions, "MIGRATE: L1.PT1")
-			return `
+				return err
+			}, libschema.After("L2", "T3")),
+			lspostgres.Generate("PT1", func(_ context.Context, _ libschema.MyLogger, _ *sql.Tx) string {
+				actions = append(actions, "MIGRATE: L1.PT1")
+				return `
 				INSERT INTO T1 (id) VALUES ('PT1');
 				INSERT INTO T2 (id) VALUES ('PT1');
 				INSERT INTO T3 (id) VALUES ('PT1');
 			`
-		}),
-	)
+			}),
+		}
+		if extra {
+			l1migrations = append(l1migrations,
+				lspostgres.Generate("G1", func(_ context.Context, _ libschema.MyLogger, _ *sql.Tx) string {
+					actions = append(actions, "MIGRATE: G1")
+					return `CREATE TABLE G1 (id text);`
+				}),
+			)
+		}
 
-	dbase.Migrations("L2",
-		lspostgres.Generate("T3", func(_ context.Context, _ libschema.MyLogger, _ *sql.Tx) string {
-			actions = append(actions, "MIGRATE: L2.T3")
-			return `
+		dbase.Migrations("L1", l1migrations...)
+
+		dbase.Migrations("L2",
+			lspostgres.Generate("T3", func(_ context.Context, _ libschema.MyLogger, _ *sql.Tx) string {
+				actions = append(actions, "MIGRATE: L2.T3")
+				return `
 				INSERT INTO T1 (id) VALUES ('T3');
 				CREATE TABLE T3 (id text)`
-		}),
-		lspostgres.Generate("T4", func(_ context.Context, _ libschema.MyLogger, _ *sql.Tx) string {
-			actions = append(actions, "MIGRATE: L2.T4")
-			return `
+			}),
+			lspostgres.Generate("T4", func(_ context.Context, _ libschema.MyLogger, _ *sql.Tx) string {
+				actions = append(actions, "MIGRATE: L2.T4")
+				return `
 				INSERT INTO T1 (id) VALUES ('T4');
 				INSERT INTO T2 (id) VALUES ('T4');
 				INSERT INTO T3 (id) VALUES ('T4');
 				CREATE TABLE T4 (id text)`
-		}),
-	)
+			}),
+		)
+	}
+
+	t.Log("now we define the migrations")
+	defineMigrations(dbase, false)
 
 	err = s.Migrate(context.Background())
 	assert.NoError(t, err)
@@ -135,4 +150,23 @@ func TestPostgresMigrations(t *testing.T) {
 		names = append(names, name)
 	}
 	assert.Equal(t, []string{"t1", "t2", "t3", "t4", "tracking_table"}, names, "table names")
+
+	s = libschema.New(context.Background(), options)
+	dbase, err = lspostgres.New(testinglogur.Get(t), "test", s, db)
+	require.NoError(t, err, "libschema NewDatabase")
+
+	t.Log("Now we define slightly more migrations")
+	defineMigrations(dbase, true)
+
+	actions = nil
+	t.Log("now we do the migrations")
+	err = s.Migrate(context.Background())
+	assert.NoError(t, err)
+
+	t.Log("now we check that the sequence of actions matches our expectations")
+	assert.Equal(t, []string{
+		"START",
+		"MIGRATE: G1",
+		"COMPLETE",
+	}, actions)
 }


### PR DESCRIPTION
Breaking change: the behavior of `MySQL.DatabaseName()` has changed.  It now defaults to `libschema.Options.SchemaOverride` if set.  `MySQL.UseDatabase()` can be used to override `DatabaseName()`

Also: instructions for running tests have been added and tests have more coverage.
