### PR TITLE
breaking change: lsmysql.CheckScript() now returns error

### DIFF
--- a/lsmysql/check.go
+++ b/lsmysql/check.go
@@ -1,53 +1,50 @@
 package lsmysql
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/muir/sqltoken"
+	"github.com/pkg/errors"
 )
 
-type CheckResult string
-
-const (
-	Safe             CheckResult = "safe"
-	DataAndDDL       CheckResult = "dataAndDDL"
-	NonIdempotentDDL CheckResult = "nonIdempotentDDL"
-)
-
+var ErrDataAndDDL = errors.New("Migration combines DDL (Data Definition Language [schema changes]) and data manipulation")
+var ErrNonIdempotentDDL = errors.New("Unconditional migration has non-idempotent DDL (Data Definition Language [schema changes])")
 var ifExistsRE = regexp.MustCompile(`(?i)\bIF (?:NOT )?EXISTS\b`)
 
 // CheckScript attempts to validate that an SQL command does not do
-// both schema changes (DDL) and data changes.
-func CheckScript(s string) CheckResult {
-	var seenDDL int
-	var seenData int
-	var idempotent int
+// both schema changes (DDL) and data changes.  The returned error
+// will be (when checked with errors.Is()) nil, ErrDataAndDDL, or
+// ErrNonIdempotentDDL.
+func CheckScript(s string) error {
+	var seenDDL string
+	var seenData string
+	var nonIdempotent string
 	ts := sqltoken.TokenizeMySQL(s)
 	for _, cmd := range ts.Strip().CmdSplit() {
 		word := strings.ToLower(cmd[0].Text)
 		switch word {
 		case "alter", "rename", "create", "drop", "comment":
-			seenDDL++
-			if ifExistsRE.MatchString(cmd.String()) {
-				idempotent++
+			seenDDL = cmd.String()
+			if !ifExistsRE.MatchString(cmd.String()) {
+				nonIdempotent = cmd.String()
 			}
 		case "truncate":
-			seenDDL++
-			idempotent++
+			seenDDL = cmd.String()
 		case "use", "set":
 			// neither
 		case "values", "table", "select":
 			// doesn't modify anything
 		case "call", "delete", "do", "handler", "import", "insert", "load", "replace", "update", "with":
-			seenData++
+			seenData = cmd.String()
 		}
 	}
-	if seenDDL > 0 && seenData > 0 {
-		return DataAndDDL
+	if seenDDL != "" && seenData != "" {
+		return fmt.Errorf("data command '%s' combined with DDL command '%s': %w", seenData, seenDDL, ErrDataAndDDL)
 	}
-	if seenDDL > idempotent {
-		return NonIdempotentDDL
+	if nonIdempotent != "" {
+		return fmt.Errorf("non-idempotent DSL '%s': %w", nonIdempotent, ErrNonIdempotentDDL)
 	}
-	return Safe
+	return nil
 }


### PR DESCRIPTION
**BREAKING CHANGE**: `lsmysql.CheckScript()` now returns `error` instead of `CheckResult`.

This change was made so that `CheckScript`'s return value could include examples.

Use `errors.Is(err, lsmysql.ErrDataAndDDL)` and `errors.Is(err, lsmysql.ErrNonIdempotentDDL)` to classify the error.