### PR TITLE
track db_names for mysql and singlestore; breaking change for singlestore

### DIFF
--- a/lsmysql/mysql.go
+++ b/lsmysql/mysql.go
@@ -249,6 +249,9 @@ func (p *MySQL) CreateSchemaTableIfNotExists(ctx context.Context, _ *internal.Lo
 
 var simpleIdentifierRE = regexp.MustCompile(`\A[A-Za-z][A-Za-z0-9_]*\z`)
 
+// WithTrackingTableQuoter is a somewhat internal function -- used by lssinglestore.
+// It replaces the private function that takes apart the name of the tracking
+// table and provides the components.
 func WithTrackingTableQuoter(f func(*libschema.Database) (schemaName, tableName, simpleTableName string, err error)) MySQLOpt {
 	return func(p *MySQL) {
 		p.trackingSchemaTable = f

--- a/lsmysql/skip.go
+++ b/lsmysql/skip.go
@@ -43,6 +43,25 @@ func (p *MySQL) HasPrimaryKey(table string) (bool, error) {
 	return count != 0, errors.Wrapf(err, "has primary key %s.%s", database, table)
 }
 
+// ColumnIsInPrimaryKey returns true if the column part of the prmary key.
+// The table is assumed to be in the current database unless m.UseDatabase() has been called.
+func (p *MySQL) ColumnIsInPrimaryKey(table string, column string) (bool, error) {
+	database, err := p.DatabaseName()
+	if err != nil {
+		return false, err
+	}
+	var count int
+	err = p.db.QueryRow(`
+		SELECT	COUNT(*)
+		FROM	information_schema.columns
+		WHERE	table_schema = ?
+		AND	table_name = ?
+		AND	column_name = ?
+		AND	column_key = 'PRI'`,
+		database, table, column).Scan(&count)
+	return count != 0, errors.Wrapf(err, "column is in primary key %s.%s.%s", database, table, column)
+}
+
 // TableHasIndex returns true if there is an index matching the
 // name given.
 // The table is assumed to be in the current database unless m.UseDatabase() has been called.

--- a/lssinglestore/unit_test.go
+++ b/lssinglestore/unit_test.go
@@ -17,12 +17,14 @@ func TestTrackingSchemaTable(t *testing.T) {
 		tt     string
 		err    bool
 		schema string
+		simple string
 		table  string
 	}{
 		{
 			tt:     "`foo`.xk-z",
 			schema: "`foo`",
 			table:  "`foo`.`xk-z`",
+			simple: "`xk-z`",
 		},
 		{
 			tt:  "`foo.xk-z",
@@ -32,6 +34,7 @@ func TestTrackingSchemaTable(t *testing.T) {
 			tt:     "foo",
 			schema: "",
 			table:  "foo",
+			simple: "foo",
 		},
 		{
 			tt:  "x.y.z",
@@ -50,13 +53,14 @@ func TestTrackingSchemaTable(t *testing.T) {
 					TrackingTable: tc.tt,
 				},
 			}
-			schema, table, err := trackingSchemaTable(d)
+			schema, table, simple, err := trackingSchemaTable(d)
 			if tc.err {
 				assert.Error(t, err)
 			} else {
 				if assert.NoError(t, err) {
 					assert.Equal(t, tc.schema, schema, "schema")
 					assert.Equal(t, tc.table, table, "table")
+					assert.Equal(t, tc.simple, simple, "simpleTable")
 				}
 			}
 		})


### PR DESCRIPTION
Add the database name to the tracking table for MySQL and SingleStore.
PostgreSQL is excluded because this change isn't as important when the underlying database supports schemas.

**THIS IS A BREAKING CHANGE**

For MySQL, the tracking table is upgraded.  The only issue is if there are multiple versions of libschema in play at once: older versions will not be able to record migrations once the table is updated.

For SingleStore, this is a complete break.  SingleStore does not currently support modifying the primary key an existing table.  The tracking table will have to be copied and re-created.  Since SingleStore support has only recently been adding, it is expected that this won't actually break anyone.   If it does, let me know and I'll add code to copy and rebuild the tracking table.
