### PR TITLE
[feat] allow migrations to be defined using sqltoken token slices

### DIFF
--- a/classifysql/classify.go
+++ b/classifysql/classify.go
@@ -105,7 +105,20 @@ func ClassifyTokens(d Dialect, majorVersion int, sqlString string) (Statements, 
 	default:
 		return nil, errors.New("invalid dialect")
 	}
-	split := tokens.CmdSplitUnstripped()
+	return ClassifyPreSplit(d, majorVersion, tokens.CmdSplitUnstripped())
+}
+
+// ClassifyPreSplit classifies already tokenized/split statements, preserving caller-provided boundaries.
+// split should contain unstripped statement tokens (like CmdSplitUnstripped output).
+func ClassifyPreSplit(d Dialect, majorVersion int, split sqltoken.TokensList) (Statements, error) {
+	switch d {
+	case DialectPostgres, DialectMySQL, DialectSingleStore:
+	default:
+		return nil, errors.New("invalid dialect")
+	}
+	if len(split) == 0 {
+		return nil, nil
+	}
 	stmts := make(Statements, len(split))
 	for i, raw := range split {
 		stmts[i].Tokens = raw

--- a/classifysql/classify_presplit_test.go
+++ b/classifysql/classify_presplit_test.go
@@ -1,0 +1,67 @@
+package classifysql
+
+import (
+	"testing"
+
+	"github.com/muir/sqltoken"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyPreSplitBoundariesPreserved(t *testing.T) {
+	// Two statements that would merge into one if re-tokenized and split differently.
+	// Using a SQL string that tokenizes into 2 separate statements.
+	tokens := sqltoken.TokenizeMySQLAPI("CREATE TABLE a (id int); INSERT INTO a VALUES (1)")
+	split := tokens.CmdSplitUnstripped()
+	require.Len(t, split, 2, "pre-condition: must have two statements")
+
+	// Feed pre-split directly: boundaries must be exactly as provided.
+	stmts, err := ClassifyPreSplit(DialectMySQL, 0, split)
+	require.NoError(t, err)
+	require.Len(t, stmts, 2, "ClassifyPreSplit must preserve caller-provided statement count")
+}
+
+func TestClassifyPreSplitCommentOnly(t *testing.T) {
+	tokens := sqltoken.TokenizePostgreSQL("-- just a comment\n")
+	split := tokens.CmdSplitUnstripped()
+
+	stmts, err := ClassifyPreSplit(DialectPostgres, 0, split)
+	require.NoError(t, err)
+	// comment-only entry must not acquire any classification flags
+	for _, st := range stmts {
+		assert.Equal(t, Flag(0), st.Flags, "comment-only statement must have no flags")
+	}
+	assert.Equal(t, 0, stmts.CountNonEmpty(), "comment-only yields zero real statements")
+}
+
+func TestClassifyPreSplitIsMultipleStatements(t *testing.T) {
+	cases := []struct {
+		name  string
+		sql   string
+		multi bool
+	}{
+		{"single statement", "CREATE TABLE t (id int)", false},
+		{"two statements", "CREATE TABLE t (id int); CREATE TABLE u (id int)", true},
+	}
+	for _, tc := range cases {
+		tokens := sqltoken.TokenizeMySQLAPI(tc.sql)
+		split := tokens.CmdSplitUnstripped()
+
+		stmts, err := ClassifyPreSplit(DialectMySQL, 0, split)
+		require.NoError(t, err, tc.name)
+		sum := stmts.Summarize()
+		_, hasMulti := sum[IsMultipleStatements]
+		assert.Equal(t, tc.multi, hasMulti, tc.name+": IsMultipleStatements mismatch")
+	}
+}
+
+func TestClassifyPreSplitInvalidDialect(t *testing.T) {
+	_, err := ClassifyPreSplit(DialectInvalid, 0, sqltoken.TokensList{})
+	require.Error(t, err)
+}
+
+func TestClassifyPreSplitEmpty(t *testing.T) {
+	stmts, err := ClassifyPreSplit(DialectMySQL, 0, nil)
+	require.NoError(t, err)
+	assert.Nil(t, stmts)
+}

--- a/lsmysql/mysql.go
+++ b/lsmysql/mysql.go
@@ -16,6 +16,7 @@ import (
 	"github.com/muir/libschema/internal"
 	"github.com/muir/libschema/internal/mhelp"
 	"github.com/muir/libschema/internal/migfinalize"
+	"github.com/muir/sqltoken"
 )
 
 // MySQL is a libschema.Driver for connecting to MySQL-like databases that
@@ -107,6 +108,7 @@ func New(log *internal.Log, dbName string, schema *libschema.Schema, db *sql.DB,
 type mmigration struct {
 	libschema.MigrationBase
 	scriptSQL    string
+	preSplitSQL  sqltoken.TokensList
 	genFn        func(context.Context, *sql.Tx) (string, error)
 	computedTx   func(context.Context, *sql.Tx) error
 	computedDB   func(context.Context, *sql.DB) error
@@ -116,6 +118,7 @@ type mmigration struct {
 func (m *mmigration) Copy() libschema.Migration {
 	n := *m
 	n.MigrationBase = m.MigrationBase.Copy()
+	n.preSplitSQL = m.preSplitSQL.Copy()
 	return &n
 }
 func (m *mmigration) Base() *libschema.MigrationBase { return &m.MigrationBase }
@@ -130,6 +133,20 @@ func (m *mmigration) Base() *libschema.MigrationBase { return &m.MigrationBase }
 func Script(name string, sqlText string, opts ...libschema.MigrationOption) libschema.Migration {
 	// Classification and validation are deferred to execution; here we only store raw SQL and options.
 	pm := &mmigration{MigrationBase: libschema.MigrationBase{Name: libschema.MigrationName{Name: name}}, scriptSQL: sqlText}
+	m := libschema.Migration(pm)
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// PreTokenized defines a migration from caller-provided pre-split statement tokens.
+// Statement boundaries are preserved exactly as provided (one Tokens per statement).
+func PreTokenized(name string, split sqltoken.TokensList, opts ...libschema.MigrationOption) libschema.Migration {
+	pm := &mmigration{
+		MigrationBase: libschema.MigrationBase{Name: libschema.MigrationName{Name: name}},
+		preSplitSQL:   split.Copy(),
+	}
 	m := libschema.Migration(pm)
 	for _, opt := range opts {
 		opt(m)
@@ -246,23 +263,33 @@ func (p *MySQL) DoOneMigration(ctx context.Context, log *internal.Log, d *libsch
 				}
 				return errors.WithStack(pm.computedConn(ctx, conn))
 			}
-			// Script or Generate path
-			sqlText := pm.scriptSQL
-			if pm.genFn != nil {
-				genSQL, gerr := pm.genFn(ctx, tx)
-				if gerr != nil {
-					return errors.WithStack(gerr)
+			var statements classifysql.Statements
+			var err error
+			if len(pm.preSplitSQL) > 0 {
+				m.Base().SetNote("sql", pm.preSplitSQL.Join().String())
+				statements, err = classifysql.ClassifyPreSplit(p.dialect, 0, pm.preSplitSQL)
+				if err != nil {
+					return errors.Wrap(err, "classify mysql pre-tokenized migration")
 				}
-				sqlText = genSQL
-			}
-			trimmedSQLText := strings.TrimSpace(sqlText)
-			m.Base().SetNote("sql", trimmedSQLText)
-			if trimmedSQLText == "" {
-				return nil
-			}
-			statements, err := classifysql.ClassifyTokens(p.dialect, 0, sqlText)
-			if err != nil {
-				return errors.Wrap(err, "classify mysql migration")
+			} else {
+				// Script or Generate path
+				sqlText := pm.scriptSQL
+				if pm.genFn != nil {
+					genSQL, gerr := pm.genFn(ctx, tx)
+					if gerr != nil {
+						return errors.WithStack(gerr)
+					}
+					sqlText = genSQL
+				}
+				trimmedSQLText := strings.TrimSpace(sqlText)
+				m.Base().SetNote("sql", trimmedSQLText)
+				if trimmedSQLText == "" {
+					return nil
+				}
+				statements, err = classifysql.ClassifyTokens(p.dialect, 0, sqlText)
+				if err != nil {
+					return errors.Wrap(err, "classify mysql migration")
+				}
 			}
 
 			summary := statements.Summarize()

--- a/lsmysql/pretokenized_test.go
+++ b/lsmysql/pretokenized_test.go
@@ -1,0 +1,46 @@
+package lsmysql_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/muir/libschema"
+	"github.com/muir/libschema/lsmysql"
+	"github.com/muir/libschema/lstesting"
+	"github.com/muir/sqltoken"
+)
+
+func TestPreTokenizedMySQL(t *testing.T) {
+	t.Parallel()
+	dsn := os.Getenv("LIBSCHEMA_MYSQL_TEST_DSN")
+	if dsn == "" {
+		t.Skip("Set $LIBSCHEMA_MYSQL_TEST_DSN to test libschema/lsmysql")
+	}
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	options, cleanup := lstesting.FakeSchema(t, "")
+	defer func() { cleanup(db) }()
+
+	s := libschema.New(context.Background(), options)
+	log := libschema.LogFromLog(t)
+	dbase, _, err := lsmysql.New(log, "test", s, db)
+	require.NoError(t, err)
+
+	split := sqltoken.TokenizeMySQLAPI(
+		"CREATE TABLE IF NOT EXISTS pretok_test (id int)",
+	).CmdSplitUnstripped()
+
+	dbase.Migrations("L1", lsmysql.PreTokenized("CREATE_TABLE", split))
+
+	require.NoError(t, s.Migrate(context.Background()))
+	m, ok := dbase.Lookup(libschema.MigrationName{Library: "L1", Name: "CREATE_TABLE"})
+	require.True(t, ok)
+	assert.True(t, m.Base().Status().Done)
+}

--- a/lspostgres/postgres.go
+++ b/lspostgres/postgres.go
@@ -18,6 +18,7 @@ import (
 	"github.com/muir/libschema/internal"
 	"github.com/muir/libschema/internal/mhelp"
 	"github.com/muir/libschema/internal/migfinalize"
+	"github.com/muir/sqltoken"
 )
 
 // Postgres is a libschema.Driver for connecting to Postgres-like databases that
@@ -43,7 +44,8 @@ type ConnPtr interface{ *sql.Tx | *sql.DB | *sql.Conn }
 
 type pmigration struct {
 	libschema.MigrationBase
-	scriptSQL string
+	scriptSQL   string
+	preSplitSQL sqltoken.TokensList
 	// genFn always uses the (string, error) internal form.
 	genFn        func(context.Context, *sql.Tx) (string, error)
 	computedTx   func(context.Context, *sql.Tx) error
@@ -65,6 +67,7 @@ func applySchemaOverridePostgres(ctx context.Context, tx mhelp.CanExecContext, o
 func (m *pmigration) Copy() libschema.Migration {
 	n := *m
 	n.MigrationBase = m.MigrationBase.Copy()
+	n.preSplitSQL = m.preSplitSQL.Copy()
 	return &n
 }
 
@@ -81,6 +84,20 @@ func (m *pmigration) Base() *libschema.MigrationBase {
 // ForceNonTransactional() or ForceTransactional() options.
 func Script(name string, sqlText string, opts ...libschema.MigrationOption) libschema.Migration {
 	pm := &pmigration{MigrationBase: libschema.MigrationBase{Name: libschema.MigrationName{Name: name}}, scriptSQL: sqlText}
+	m := libschema.Migration(pm)
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// PreTokenized defines a migration from caller-provided pre-split statement tokens.
+// Statement boundaries are preserved exactly as provided (one Tokens per statement).
+func PreTokenized(name string, split sqltoken.TokensList, opts ...libschema.MigrationOption) libschema.Migration {
+	pm := &pmigration{
+		MigrationBase: libschema.MigrationBase{Name: libschema.MigrationName{Name: name}},
+		preSplitSQL:   split.Copy(),
+	}
 	m := libschema.Migration(pm)
 	for _, opt := range opts {
 		opt(m)
@@ -210,24 +227,33 @@ func (p *Postgres) DoOneMigration(ctx context.Context, log *internal.Log, d *lib
 				}
 				return errors.Wrapf(pm.computedConn(ctx, conn), "callback %s", m.Base().Name)
 			}
-			// Script / Generate path
-			scriptSQL := pm.scriptSQL
-			if pm.genFn != nil {
-				sqlText, err := pm.genFn(ctx, tx)
+			var statements classifysql.Statements
+			var err error
+			if len(pm.preSplitSQL) > 0 {
+				m.Base().SetNote("sql", pm.preSplitSQL.Join().String())
+				statements, err = classifysql.ClassifyPreSplit(classifysql.DialectPostgres, p.serverMajor, pm.preSplitSQL)
 				if err != nil {
-					return errors.WithStack(err)
+					return errors.Wrap(err, "classify postgres pre-tokenized migration")
 				}
-				scriptSQL = sqlText
-			}
-			trimmedScriptSQL := strings.TrimSpace(scriptSQL)
-			m.Base().SetNote("sql", trimmedScriptSQL)
-			if trimmedScriptSQL == "" {
-				return nil
-			}
-			// Classification & downgrade via classifysql
-			statements, err := classifysql.ClassifyTokens(classifysql.DialectPostgres, p.serverMajor, scriptSQL)
-			if err != nil {
-				return errors.Wrap(err, "classify postgres migration")
+			} else {
+				// Script / Generate path
+				scriptSQL := pm.scriptSQL
+				if pm.genFn != nil {
+					sqlText, err := pm.genFn(ctx, tx)
+					if err != nil {
+						return errors.WithStack(err)
+					}
+					scriptSQL = sqlText
+				}
+				trimmedScriptSQL := strings.TrimSpace(scriptSQL)
+				if trimmedScriptSQL == "" {
+					return nil
+				}
+				m.Base().SetNote("sql", trimmedScriptSQL)
+				statements, err = classifysql.ClassifyTokens(classifysql.DialectPostgres, p.serverMajor, scriptSQL)
+				if err != nil {
+					return errors.Wrap(err, "classify postgres migration")
+				}
 			}
 			// Determine if transactional of not (if not already known)
 			if !pm.Base().ForcedTransactional() && !pm.Base().NonTransactional() {

--- a/lspostgres/postgres.go
+++ b/lspostgres/postgres.go
@@ -498,7 +498,7 @@ func (p *Postgres) IsMigrationSupported(d *libschema.Database, _ *internal.Log, 
 	if !ok {
 		return errors.Errorf("non-postgres migration %s registered with postgres migrations", migration.Base().Name)
 	}
-	if m.genFn != nil || m.computedTx != nil || m.computedDB != nil || m.scriptSQL != "" || m.computedConn != nil {
+	if m.genFn != nil || m.computedTx != nil || m.computedDB != nil || m.scriptSQL != "" || m.computedConn != nil || len(m.preSplitSQL) > 0 {
 		return nil
 	}
 	return errors.Errorf("migration %s is not supported", migration.Base().Name)

--- a/lspostgres/pretokenized_test.go
+++ b/lspostgres/pretokenized_test.go
@@ -1,0 +1,64 @@
+package lspostgres
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/muir/libschema"
+	"github.com/muir/libschema/lstesting"
+	"github.com/muir/sqltoken"
+)
+
+func TestIsMigrationSupportedPreTokenized(t *testing.T) {
+	p := &Postgres{}
+	split := sqltoken.TokenizePostgreSQL("CREATE TABLE t (id int)").CmdSplitUnstripped()
+
+	m := PreTokenized("test", split)
+	err := p.IsMigrationSupported(nil, nil, m)
+	assert.NoError(t, err, "PreTokenized migration must be accepted by IsMigrationSupported")
+}
+
+func TestIsMigrationSupportedEmpty(t *testing.T) {
+	p := &Postgres{}
+	// A pmigration with nothing set is not supported.
+	pm := &pmigration{MigrationBase: libschema.MigrationBase{Name: libschema.MigrationName{Name: "empty"}}}
+	err := p.IsMigrationSupported(nil, nil, pm)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported")
+}
+
+func TestPreTokenizedPostgres(t *testing.T) {
+	dsn := os.Getenv("LIBSCHEMA_POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("Set $LIBSCHEMA_POSTGRES_TEST_DSN to run Postgres tests")
+	}
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	opts, cleanup := lstesting.FakeSchema(t, "CASCADE")
+	defer cleanup(db)
+	_, err = db.Exec("CREATE SCHEMA " + opts.SchemaOverride)
+	require.NoError(t, err)
+
+	s := libschema.New(context.Background(), opts)
+	log := libschema.LogFromLog(t)
+	ldb, err := New(log, "test", s, db)
+	require.NoError(t, err)
+
+	split := sqltoken.TokenizePostgreSQL(
+		"CREATE TABLE IF NOT EXISTS pretok_test (id int)",
+	).CmdSplitUnstripped()
+
+	ldb.Migrations("L1", PreTokenized("CREATE_TABLE", split))
+
+	require.NoError(t, s.Migrate(context.Background()))
+	m, ok := ldb.Lookup(libschema.MigrationName{Library: "L1", Name: "CREATE_TABLE"})
+	require.True(t, ok)
+	assert.True(t, m.Base().Status().Done)
+}

--- a/lssinglestore/singlestore.go
+++ b/lssinglestore/singlestore.go
@@ -15,6 +15,7 @@ import (
 	"github.com/muir/libschema/classifysql"
 	"github.com/muir/libschema/internal"
 	"github.com/muir/libschema/lsmysql"
+	"github.com/muir/sqltoken"
 )
 
 // SingleStore is a libschema.Driver for connecting to SingleStore databases.
@@ -77,6 +78,12 @@ func New(log *internal.Log, dbName string, schema *libschema.Schema, db *sql.DB)
 func Script(name string, sqlText string, opts ...libschema.MigrationOption) libschema.Migration {
 	// Delegates to MySQL implementation which now applies ApplyForceOverride early.
 	return lsmysql.Script(name, sqlText, opts...)
+}
+
+// PreTokenized defines a migration from caller-provided pre-split statement tokens.
+// Statement boundaries are preserved exactly as provided (one Tokens per statement).
+func PreTokenized(name string, split sqltoken.TokensList, opts ...libschema.MigrationOption) libschema.Migration {
+	return lsmysql.PreTokenized(name, split, opts...)
 }
 
 // Generate registers a callback that returns a migration in a string.


### PR DESCRIPTION
This adds a new way to define a migration: with sqltoken tokens.
