### PR TITLE
[feat] support database reconnect after migration

### DIFF
--- a/api.go
+++ b/api.go
@@ -45,10 +45,15 @@ type Driver interface {
 	// IsMigrationSupported exists to guard against additional migration
 	// options and features.  It should return nil except if there are new
 	// migration features added that haven't been included in all support
-	// libraries.
+	// libraries. IsMigrationSupported does not need to check if the migration
+	// requires ReconnectAfter
 	IsMigrationSupported(*Database, *internal.Log, Migration) error
 
-	LoadStatus(context.Context, *internal.Log, *Database) ([]MigrationName, error)
+	// LoadStatus loads the current status of all migrations from the migration tracking table.
+	// It modifies the migrations that have been defined to note their status.
+	// It returns the names of any unknown migrations, that exist in the status table,
+	// but haven't been defined.
+	LoadStatus(context.Context, *internal.Log, *Database) (unknownMigrations []MigrationName, _ error)
 }
 
 // MigrationName holds both the name of the specific migration and the library to
@@ -76,6 +81,7 @@ type MigrationBase struct {
 	notes              map[string]any
 	preserveComments   bool
 	skipClassification bool
+	reconnectAfter     bool
 }
 
 func (m MigrationBase) Copy() MigrationBase {
@@ -114,6 +120,7 @@ type Database struct {
 	migrationIndex    map[MigrationName]Migration
 	errors            []error
 	db                *sql.DB
+	reconnect         func() (*sql.DB, error)
 	DBName            string
 	driver            Driver
 	sequence          []Migration // in order of execution
@@ -123,6 +130,7 @@ type Database struct {
 	log               *internal.Log
 	asyncInProgress   bool
 	unknownMigrations []MigrationName
+	migrationsLocked  bool
 }
 
 // Options operate at the Database level but are specified at the Schema level
@@ -210,6 +218,25 @@ func (s *Schema) NewDatabase(log *internal.Log, dbName string, db *sql.DB, drive
 	return database, nil
 }
 
+// NewDatabaseWithOpener creates a Database object.  For Postgres and Mysql this is bundled into
+// lspostgres.NewWithOpener() and lsmysql.NewWithOpener().
+//
+// It is the caller's responsibility to eventually call database.DB().Close() when using
+// NewDatabaseWithOpener().
+func (s *Schema) NewDatabaseWithOpener(log *internal.Log, dbName string, opener func() (*sql.DB, error), driver Driver) (*Database, error) {
+	db, err := opener()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	database, err := s.NewDatabase(log, dbName, db, driver)
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	database.reconnect = opener
+	return database, nil
+}
+
 // Asynchronous marks a migration is okay to run asynchronously.  If all of the
 // remaining migrations can be asynchronous, then schema.Migrate() will return
 // while the remaining migrations run.
@@ -269,6 +296,15 @@ func After(lib, migration string) MigrationOption {
 func SkipIf(pred func() (bool, error)) MigrationOption {
 	return func(m Migration) {
 		m.Base().skipIf = pred
+	}
+}
+
+// ReconnectAfter directs libschema to close the database connection and
+// reopen it after applying this migration. This requires that the Database
+// be created with NewDatabaseWithOpener.
+func ReconnectAfter() MigrationOption {
+	return func(m Migration) {
+		m.Base().reconnectAfter = true
 	}
 }
 
@@ -444,6 +480,9 @@ func (m *MigrationBase) ForcedNonTransactional() bool { return m.forcedTx != nil
 
 // PreserveComments reports if PreserveComments() was set on this migration.
 func (m *MigrationBase) PreserveComments() bool { return m.preserveComments }
+
+// ReconnectAfter reports if ReconnectAfter() was set on this migration.
+func (m *MigrationBase) ReconnectAfter() bool { return m.reconnectAfter }
 
 func (n MigrationName) String() string {
 	return n.Library + ": " + n.Name

--- a/apply.go
+++ b/apply.go
@@ -120,10 +120,14 @@ func (d *Database) prepare(ctx context.Context) error {
 		return err
 	}
 
+	if d.migrationsLocked {
+		return errors.Errorf("migrations already locked by this Database")
+	}
 	err = d.driver.LockMigrationsTable(ctx, d.log, d)
 	if err != nil {
 		return err
 	}
+	d.migrationsLocked = true
 
 	d.unknownMigrations, err = d.driver.LoadStatus(ctx, d.log, d)
 	if err != nil {
@@ -250,6 +254,19 @@ func (d *Database) doOneMigration(ctx context.Context, m Migration) (bool, error
 			"name":     m.Base().Name.Name,
 		})
 	}
+	if m.Base().ReconnectAfter() && !d.CanReconnect() {
+		err := errors.Errorf("reconnect-after required for migration %s but database not created with that capability", m.Base().Name)
+		d.log.Info(" migration not supported", map[string]any{
+			"database": d.DBName,
+			"library":  m.Base().Name.Library,
+			"name":     m.Base().Name.Name,
+			"error":    err.Error(),
+		})
+		m.Base().SetNote("applied", false)
+		m.Base().SetNote("reason", "not supported")
+		m.Base().SetNote("error", err)
+		return false, err
+	}
 	if err := d.driver.IsMigrationSupported(d, d.log, m); err != nil {
 		d.log.Info(" migration not supported", map[string]any{
 			"database": d.DBName,
@@ -316,11 +333,11 @@ func (d *Database) doOneMigration(ctx context.Context, m Migration) (bool, error
 			return false, errors.Wrapf(err, "migration %s in library %s failed", m.Base().Name.Name, m.Base().Name.Library)
 		}
 
-		if m.Base().repeatUntilNoOp && err == nil {
+		if m.Base().repeatUntilNoOp {
 			totalRowsModified += rowsAffected
 			m.Base().SetNote("rows_modified", totalRowsModified)
 			if rowsAffected == 0 {
-				return false, nil
+				break
 			}
 			repeatCount++
 			m.Base().SetNote("repeat_count", repeatCount)
@@ -330,8 +347,15 @@ func (d *Database) doOneMigration(ctx context.Context, m Migration) (bool, error
 			})
 			continue
 		}
-		return false, nil
+		break
 	}
+	if m.Base().ReconnectAfter() {
+		err := d.Reconnect(ctx)
+		if err != nil {
+			return true, errors.Wrapf(err, "reconnect after completing migration %s", m.Base().Name.Name)
+		}
+	}
+	return false, nil
 }
 
 func (d *Database) lastUnfinishedSynchrnous() int {
@@ -402,7 +426,64 @@ func (d *Database) asyncMigrate(ctx context.Context) {
 
 func (d *Database) unlock() error {
 	if !d.asyncInProgress {
-		return d.driver.UnlockMigrationsTable(d.log)
+		if d.migrationsLocked {
+			err := d.driver.UnlockMigrationsTable(d.log)
+			if err != nil {
+				return err
+			}
+			d.migrationsLocked = false
+		}
+	}
+	return nil
+}
+
+func (d *Database) CanReconnect() bool {
+	if d.Options.Overrides != nil && d.Options.Overrides.MigrateDSN != "" {
+		return false
+	}
+	return d.reconnect != nil
+}
+
+func (d *Database) Reconnect(ctx context.Context) (err error) {
+	if !d.CanReconnect() {
+		return errors.Errorf("reconnect not supported")
+	}
+	db, err := d.reconnect()
+	if err != nil {
+		return errors.Wrap(err, "reconnect to database")
+	}
+	defer func() {
+		if err != nil && db != nil {
+			_ = db.Close()
+		}
+	}()
+	relock := d.migrationsLocked
+	if d.db != nil {
+		if d.migrationsLocked {
+			// Drop lock using old db
+			err := d.driver.UnlockMigrationsTable(d.log)
+			if err != nil {
+				return err
+			}
+			d.migrationsLocked = false
+		}
+		err = d.db.Close()
+		if err != nil {
+			return errors.Wrap(err, "close prior database")
+		}
+	}
+	d.db = db
+	db = nil // no longer try to close
+	if relock {
+		err = d.driver.LockMigrationsTable(ctx, d.log, d)
+		if err != nil {
+			return err
+		}
+		d.migrationsLocked = true
+		d.unknownMigrations, err = d.driver.LoadStatus(ctx, d.log, d)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ type OverrideOptions struct {
 
 	// MigrateDSN overrides the data source name for a single database.  It must be used in
 	// conjunction with MigrateDatabase unless there are only migrations for a single database.
+	// MigrateDSN is not compatible with ReconnectAfter migrations.
 	MigrateDSN string `flag:"migrate-dsn" help:"Override *sql.DB, must combine with --migrate-database"`
 
 	// NoMigrate command line flag / config variable skips all migrations

--- a/lsmysql/mysql.go
+++ b/lsmysql/mysql.go
@@ -47,12 +47,13 @@ import (
 type MySQL struct {
 	lockTx              *sql.Tx
 	lockStr             string
-	db                  *sql.DB
+	database            *libschema.Database
 	databaseName        string
 	lock                sync.Mutex
 	trackingSchemaTable func(*libschema.Database) (string, string, string, error)
 	skipDatabase        bool
 	dialect             classifysql.Dialect
+	optDB               *sql.DB // not nil when m.skipDatabase is true
 }
 
 // applySchemaOverrideMySQL sets the database (schema) for the current connection/transaction
@@ -80,13 +81,35 @@ func WithoutDatabase(p *MySQL) {
 	p.skipDatabase = true
 }
 
+// WithDatabase provides a pre-created libschema.Database for MySQL to use
+func WithDatabase(database *libschema.Database) MySQLOpt {
+	return func(p *MySQL) {
+		p.database = database
+		p.databaseName = database.Options.SchemaOverride
+	}
+}
+
 // New creates a libschema.Database with a mysql driver built in.  The dbName
-// parameter specifies the name of the database, but that name is not actaully
+// parameter specifies the name of the database, but that name is not actually
 // used anywhere except for logging.  To override the database used for the
 // migrations set the SchemaOverride option.
 func New(log *internal.Log, dbName string, schema *libschema.Schema, db *sql.DB, options ...MySQLOpt) (*libschema.Database, *MySQL, error) {
+	return newMaybeWithOpener(log, dbName, schema, db, nil, options...)
+}
+
+// NewWithOpener creates a libschema.Database with a mysql driver built in.  The dbName
+// parameter specifies the name of the database, but that name is not actually
+// used anywhere except for logging.  To override the database used for the
+// migrations set the SchemaOverride option.
+//
+// It is the caller's responsibility to eventually call either database.DB().Close()
+// or mysql.DB().Close()
+func NewWithOpener(log *internal.Log, dbName string, schema *libschema.Schema, opener func() (*sql.DB, error), options ...MySQLOpt) (*libschema.Database, *MySQL, error) {
+	return newMaybeWithOpener(log, dbName, schema, nil, opener, options...)
+}
+
+func newMaybeWithOpener(log *internal.Log, dbName string, schema *libschema.Schema, maybeDB *sql.DB, maybeOpener func() (*sql.DB, error), options ...MySQLOpt) (*libschema.Database, *MySQL, error) {
 	m := &MySQL{
-		db:                  db,
 		trackingSchemaTable: trackingSchemaTable,
 		dialect:             classifysql.DialectMySQL,
 	}
@@ -94,13 +117,32 @@ func New(log *internal.Log, dbName string, schema *libschema.Schema, db *sql.DB,
 		opt(m)
 	}
 	var d *libschema.Database
-	if !m.skipDatabase {
+	switch {
+	case m.database != nil:
+		// WithDatabase was used
+		d = m.database
+	case m.skipDatabase:
+		if maybeDB != nil {
+			m.optDB = maybeDB
+		} else {
+			var err error
+			m.optDB, err = maybeOpener()
+			if err != nil {
+				return nil, nil, errors.Wrap(err, "open database")
+			}
+		}
+	default:
 		var err error
-		d, err = schema.NewDatabase(log, dbName, db, m)
+		if maybeDB != nil {
+			d, err = schema.NewDatabase(log, dbName, maybeDB, m)
+		} else {
+			d, err = schema.NewDatabaseWithOpener(log, dbName, maybeOpener, m)
+		}
 		if err != nil {
 			return nil, nil, err
 		}
 		m.databaseName = d.Options.SchemaOverride
+		m.database = d
 	}
 	return d, m, nil
 }
@@ -608,4 +650,11 @@ func (p *MySQL) IsMigrationSupported(d *libschema.Database, _ *internal.Log, mig
 	}
 	// All mmigration instances are supported; body presence checked at execution.
 	return nil
+}
+
+func (p *MySQL) DB() *sql.DB {
+	if p.database != nil {
+		return p.database.DB()
+	}
+	return p.optDB
 }

--- a/lsmysql/reconnect_test.go
+++ b/lsmysql/reconnect_test.go
@@ -1,0 +1,88 @@
+package lsmysql_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/muir/libschema"
+	"github.com/muir/libschema/lsmysql"
+	"github.com/muir/libschema/lssinglestore"
+	"github.com/muir/libschema/lstesting"
+)
+
+type reconnectNewWithOpener func(
+	t *testing.T,
+	name string,
+	schema *libschema.Schema,
+	getDB func() (*sql.DB, error),
+) (*libschema.Database, error)
+
+type reconnectScript func(name, sqlText string, opts ...libschema.MigrationOption) libschema.Migration
+
+func testReconnectAfter(
+	t *testing.T,
+	dsn string,
+	newWithOpener reconnectNewWithOpener,
+	script reconnectScript,
+) {
+	options, cleanup := lstesting.FakeSchema(t, "")
+	adminDB, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, adminDB.Close()) }()
+	defer cleanup(adminDB)
+
+	var openerCalls int32
+	openDB := func() (*sql.DB, error) {
+		atomic.AddInt32(&openerCalls, 1)
+		return sql.Open("mysql", dsn)
+	}
+
+	s := libschema.New(context.Background(), options)
+	dbase, err := newWithOpener(t, "test", s, openDB)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, dbase.DB().Close()) }()
+
+	dbase.Migrations("L1", script("R1", `SELECT 1`, libschema.ReconnectAfter()))
+	require.NoError(t, s.Migrate(context.Background()))
+	assert.Equal(t, int32(2), atomic.LoadInt32(&openerCalls))
+}
+
+func TestMysqlReconnectAfter(t *testing.T) {
+	t.Parallel()
+	dsn := os.Getenv("LIBSCHEMA_MYSQL_TEST_DSN")
+	if dsn == "" {
+		t.Skip("Set $LIBSCHEMA_MYSQL_TEST_DSN to test libschema/lsmysql")
+	}
+	testReconnectAfter(
+		t,
+		dsn,
+		func(t *testing.T, name string, schema *libschema.Schema, getDB func() (*sql.DB, error)) (*libschema.Database, error) {
+			dbase, _, err := lsmysql.NewWithOpener(libschema.LogFromLog(t), name, schema, getDB)
+			return dbase, err
+		},
+		lsmysql.Script,
+	)
+}
+
+func TestSingleStoreReconnectAfter(t *testing.T) {
+	t.Parallel()
+	dsn := os.Getenv("LIBSCHEMA_SINGLESTORE_TEST_DSN")
+	if dsn == "" {
+		t.Skip("Set $LIBSCHEMA_SINGLESTORE_TEST_DSN to test SingleStore support in libschema/lsmysql")
+	}
+	testReconnectAfter(
+		t,
+		dsn,
+		func(t *testing.T, name string, schema *libschema.Schema, getDB func() (*sql.DB, error)) (*libschema.Database, error) {
+			dbase, _, err := lssinglestore.NewWithOpener(libschema.LogFromLog(t), name, schema, getDB)
+			return dbase, err
+		},
+		lssinglestore.Script,
+	)
+}

--- a/lsmysql/skip.go
+++ b/lsmysql/skip.go
@@ -15,7 +15,7 @@ func (p *MySQL) ColumnDefault(table, column string) (*string, error) {
 		return nil, err
 	}
 	var dflt *string
-	err = p.db.QueryRow(`
+	err = p.DB().QueryRow(`
 		SELECT	column_default
 		FROM	information_schema.columns
 		WHERE	table_schema = ?
@@ -33,7 +33,7 @@ func (p *MySQL) HasPrimaryKey(table string) (bool, error) {
 		return false, err
 	}
 	var count int
-	err = p.db.QueryRow(`
+	err = p.DB().QueryRow(`
 		SELECT	COUNT(*)
 		FROM	information_schema.columns
 		WHERE	table_schema = ?
@@ -51,7 +51,7 @@ func (p *MySQL) ColumnIsInPrimaryKey(table string, column string) (bool, error) 
 		return false, err
 	}
 	var count int
-	err = p.db.QueryRow(`
+	err = p.DB().QueryRow(`
 		SELECT	COUNT(*)
 		FROM	information_schema.columns
 		WHERE	table_schema = ?
@@ -71,7 +71,7 @@ func (p *MySQL) TableHasIndex(table, indexName string) (bool, error) {
 		return false, err
 	}
 	var count int
-	err = p.db.QueryRow(`
+	err = p.DB().QueryRow(`
 		SELECT	COUNT(*)
 		FROM	information_schema.statistics
 		WHERE	table_schema = ?
@@ -89,7 +89,7 @@ func (p *MySQL) DoesColumnExist(table, column string) (bool, error) {
 		return false, err
 	}
 	var count int
-	err = p.db.QueryRow(`
+	err = p.DB().QueryRow(`
 		SELECT	COUNT(*)
 		FROM	information_schema.columns
 		WHERE	table_schema = ?
@@ -108,7 +108,7 @@ func (p *MySQL) GetTableConstraint(table, constraintName string) (string, bool, 
 	}
 	var typ *string
 	var enforced *string
-	err = p.db.QueryRow(`
+	err = p.DB().QueryRow(`
 		SELECT	constraint_type, enforced
 		FROM	information_schema.table_constraints
 		WHERE	constraint_schema = ?
@@ -124,14 +124,14 @@ func (p *MySQL) GetTableConstraint(table, constraintName string) (string, bool, 
 // DatabaseName returns the name of the current database (aka schema for MySQL).
 // A call to UseDatabase() overrides all future calls to DatabaseName().  If the
 // MySQL object was created from a libschema.Schema that had SchemaOverride set
-// then this will return whatever that value was.  It is reccomened that
+// then this will return whatever that value was.  It is recommended that
 // UseDatabase() be called to make sure that the right database is returned.
-func (m *MySQL) DatabaseName() (string, error) {
-	if m.databaseName != "" {
-		return m.databaseName, nil
+func (p *MySQL) DatabaseName() (string, error) {
+	if p.databaseName != "" {
+		return p.databaseName, nil
 	}
 	var database string
-	err := m.db.QueryRow(`SELECT DATABASE()`).Scan(&database)
+	err := p.DB().QueryRow(`SELECT DATABASE()`).Scan(&database)
 	return database, errors.Wrap(err, "select database()")
 }
 

--- a/lspostgres/config_test.go
+++ b/lspostgres/config_test.go
@@ -181,10 +181,15 @@ func doConfigMigrate(t *testing.T, options *libschema.Options, dsn string, expec
 	if err != nil {
 		return nil, errors.Wrap(err, "open")
 	}
+	var dbase *libschema.Database
 	defer func() {
 		if options == nil {
 			t.Log("Closing db...")
-			assert.NoError(t, db.Close())
+			if dbase != nil {
+				assert.NoError(t, dbase.DB().Close())
+			} else {
+				assert.NoError(t, db.Close())
+			}
 			t.Log("done")
 		}
 	}()
@@ -234,7 +239,7 @@ func doConfigMigrate(t *testing.T, options *libschema.Options, dsn string, expec
 		)
 	}
 
-	dbase, err := lspostgres.New(libschema.LogFromLog(t), "test", s, db)
+	dbase, err = lspostgres.New(libschema.LogFromLog(t), "test", s, db)
 	if err != nil {
 		return db, errors.Wrap(err, "new")
 	}

--- a/lspostgres/postgres.go
+++ b/lspostgres/postgres.go
@@ -40,6 +40,15 @@ func New(log *internal.Log, dbName string, schema *libschema.Schema, db *sql.DB)
 	return schema.NewDatabase(log, dbName, db, &Postgres{log: log})
 }
 
+// NewWithOpener creates a libschema.Database with a postgres driver built in.  The dbName
+// parameter is used internally by libschema, but does not affect where migrations
+// are actually applied.
+//
+// It is the caller's responsibility to eventually call database.DB().Close()
+func NewWithOpener(log *internal.Log, dbName string, schema *libschema.Schema, opener func() (*sql.DB, error)) (*libschema.Database, error) {
+	return schema.NewDatabaseWithOpener(log, dbName, opener, &Postgres{log: log})
+}
+
 type ConnPtr interface{ *sql.Tx | *sql.DB | *sql.Conn }
 
 type pmigration struct {

--- a/lssinglestore/computed_failure_test.go
+++ b/lssinglestore/computed_failure_test.go
@@ -30,6 +30,7 @@ func TestComputedFailure(t *testing.T) {
 	log := libschema.LogFromLog(t)
 	dbase, _, err := New(log, "test_singlestore_fail", s, db)
 	require.NoError(t, err)
+	require.NotNil(t, dbase)
 
 	lib := time.Now().Format("FAIL_20060102150405.000000000")
 	failErr := errors.New("boom-fail-singlestore")

--- a/lssinglestore/empty_script_test.go
+++ b/lssinglestore/empty_script_test.go
@@ -31,6 +31,7 @@ func TestEmptyScriptNoOp(t *testing.T) {
 	log := libschema.LogFromLog(t)
 	dbase, _, err := lssinglestore.New(log, "test", s, db)
 	require.NoError(t, err)
+	require.NotNil(t, dbase)
 
 	dbase.Migrations("L1",
 		lssinglestore.Script("EMPTY", ""),

--- a/lssinglestore/inference_test.go
+++ b/lssinglestore/inference_test.go
@@ -35,6 +35,7 @@ func TestComputedInference(t *testing.T) {
 	log := libschema.LogFromLog(t)
 	dbase, _, err := lssinglestore.New(log, "test", s, db)
 	require.NoError(t, err)
+	require.NotNil(t, dbase)
 
 	calledTx := false
 	calledDB := false
@@ -58,6 +59,7 @@ func TestForceOverride(t *testing.T) {
 	log := libschema.LogFromLog(t)
 	dbase, _, err := lssinglestore.New(log, "test", s, db)
 	require.NoError(t, err)
+	require.NotNil(t, dbase)
 
 	forcedTx := lssinglestore.Script("FORCE_TX", "SELECT 1", libschema.ForceTransactional())
 	forcedNonTx := lssinglestore.Script("FORCE_NONTX", "SELECT 1", libschema.ForceNonTransactional())

--- a/lssinglestore/repeat_test.go
+++ b/lssinglestore/repeat_test.go
@@ -32,6 +32,7 @@ func TestRepeat(t *testing.T) {
 	log := libschema.LogFromLog(t)
 	dbase, _, err := lssinglestore.New(log, "test", s, db)
 	require.NoError(t, err)
+	require.NotNil(t, dbase)
 
 	dbase.Migrations("L1",
 		lssinglestore.Script("M1", `CREATE TABLE IF NOT EXISTS m1 (id text)`),

--- a/lssinglestore/singlestore.go
+++ b/lssinglestore/singlestore.go
@@ -40,31 +40,55 @@ type SingleStore struct {
 	*lsmysql.MySQL
 	lockTx *sql.Tx
 	lock   sync.Mutex
-	db     *sql.DB
 }
 
 // New creates a libschema.Database with a Singlestore driver built in.
 func New(log *internal.Log, dbName string, schema *libschema.Schema, db *sql.DB) (*libschema.Database, *SingleStore, error) {
-	_, mysql, err := lsmysql.New(log, dbName, schema, db,
-		lsmysql.WithoutDatabase,
+	return newMaybeWithOpener(log, dbName, schema, db, nil)
+}
+
+// NewWithOpener creates a libschema.Database with a Singlestore driver built in.
+//
+// It is the caller's responsibility to eventually call either database.DB().Close()
+// or singlestore.DB().Close()
+func NewWithOpener(log *internal.Log, dbName string, schema *libschema.Schema, opener func() (*sql.DB, error)) (*libschema.Database, *SingleStore, error) {
+	return newMaybeWithOpener(log, dbName, schema, nil, opener)
+}
+
+func newMaybeWithOpener(log *internal.Log, dbName string, schema *libschema.Schema, optDB *sql.DB, optOpener func() (*sql.DB, error)) (*libschema.Database, *SingleStore, error) {
+	s2 := &SingleStore{}
+	var database *libschema.Database
+	var err error
+	if optDB != nil {
+		database, err = schema.NewDatabase(log, dbName, optDB, s2)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		database, err = schema.NewDatabaseWithOpener(log, dbName, optOpener, s2)
+		if err != nil {
+			if database != nil {
+				db := database.DB()
+				if db != nil {
+					_ = db.Close()
+				}
+			}
+			return nil, nil, err
+		}
+	}
+	opts := []lsmysql.MySQLOpt{
+		lsmysql.WithDatabase(database),
 		lsmysql.WithTrackingTableQuoter(trackingSchemaTable),
 		lsmysql.WithDialect(classifysql.DialectSingleStore),
-	)
+	}
+	_, mysql, err := lsmysql.New(log, dbName, schema, nil, opts...)
 	if err != nil {
+		if optDB == nil {
+			_ = database.DB().Close()
+		}
 		return nil, nil, err
 	}
-	s2 := &SingleStore{
-		MySQL: mysql,
-		db:    db,
-	}
-	database, err := schema.NewDatabase(log, dbName, db, s2)
-	if err != nil {
-		return nil, nil, err
-	}
-	if database.Options.SchemaOverride != "" {
-		//nolint:staticcheck // QF1008: could remove embedded field "MySQL" from selector
-		s2.MySQL.UseDatabase(database.Options.SchemaOverride)
-	}
+	s2.MySQL = mysql
 	return database, s2, nil
 }
 
@@ -247,7 +271,7 @@ func (p *SingleStore) GetTableConstraint(table, constraintName string) (string, 
 		return "", false, err
 	}
 	var typ *string
-	err = p.db.QueryRow(`
+	err = p.DB().QueryRow(`
 		SELECT	constraint_type
 		FROM	information_schema.table_constraints
 		WHERE	constraint_schema = ?

--- a/lssinglestore/skip_test.go
+++ b/lssinglestore/skip_test.go
@@ -34,6 +34,7 @@ func TestSingleStoreSkipFunctions(t *testing.T) {
 
 	dbase, m, err := lssinglestore.New(libschema.LogFromLog(t), "test", s, db)
 	require.NoError(t, err, "libschema NewDatabase")
+	require.NotNil(t, dbase)
 
 	dbase.Migrations("T",
 		lssinglestore.Script("setup1", `


### PR DESCRIPTION
Adds `NewWithOpener` for passing in a function to open the database.
Add `ReconnectAfter` migration option so that post-migration the database is re-opened.

Resolves #351 