### PR TITLE
[feat] CloseOnComplete; minimum go version now 1.22

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - name: Run coverage
         run: make calculate_coverage
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
   Build-and-test:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x, 1.23.x, 1.24.x]
+        go-version: [1.22.x, 1.23.x, 1.24.x, 1.25.x, 1.26.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/pg.yml
+++ b/.github/workflows/pg.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/s2.yml
+++ b/.github/workflows/s2.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: Build
         run: go build -v ./...

--- a/api.go
+++ b/api.go
@@ -3,6 +3,7 @@ package libschema
 import (
 	"context"
 	"database/sql"
+	"sync/atomic"
 
 	"github.com/memsql/errors"
 
@@ -128,9 +129,10 @@ type Database struct {
 	parent            *Schema
 	Options           Options
 	log               *internal.Log
-	asyncInProgress   bool
+	asyncInProgress   atomic.Bool
 	unknownMigrations []MigrationName
 	migrationsLocked  bool
+	allDoneDone       atomic.Int32 // 0 until allDone called
 }
 
 // Options operate at the Database level but are specified at the Schema level
@@ -165,10 +167,15 @@ type Options struct {
 	// OnMigrationsStarted is called for each Database (if needed).
 	OnMigrationsStarted func(dbase *Database)
 
-	// OnMigrationsComplete called even if no migrations are needed.  It
+	// OnMigrationsComplete is called even if no migrations are needed. It
 	// will be called when async migrations finish even if they finish
-	// with an error.  OnMigrationsComplete is called for each Database.
+	// with an error.  OnMigrationsComplete is called for each Database,
+	// even for ones excluded by other options (eg MigrateDatabase)
 	OnMigrationsComplete func(dbase *Database, err error)
+
+	// CloseOnComplete causes the database handled to be closed when the
+	// migrations are complete, regardless of outcome.
+	CloseOnComplete bool
 
 	// DebugLogging turns on extra debug logging
 	DebugLogging bool
@@ -222,7 +229,7 @@ func (s *Schema) NewDatabase(log *internal.Log, dbName string, db *sql.DB, drive
 // lspostgres.NewWithOpener() and lsmysql.NewWithOpener().
 //
 // It is the caller's responsibility to eventually call database.DB().Close() when using
-// NewDatabaseWithOpener().
+// NewDatabaseWithOpener(). The simple way to do that is to set the CloseOnComplete option.
 func (s *Schema) NewDatabaseWithOpener(log *internal.Log, dbName string, opener func() (*sql.DB, error), driver Driver) (*Database, error) {
 	db, err := opener()
 	if err != nil {

--- a/apply.go
+++ b/apply.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/memsql/errors"
 
 	"github.com/muir/libschema/dgorder"
@@ -30,10 +29,13 @@ func (s *Schema) Migrate(ctx context.Context) (err error) {
 			os.Exit(0)
 		}()
 	}
-	if s.options.Overrides.NoMigrate {
-		return nil
-	}
 	todo := s.databaseOrder
+	for _, d := range todo {
+		d.allDoneDone.Store(0)
+		defer func() {
+			d.allDone(nil, err)
+		}()
+	}
 	if s.options.Overrides.MigrateDatabase != "" {
 		if d, ok := s.databases[s.options.Overrides.MigrateDatabase]; ok {
 			todo = []*Database{d}
@@ -44,11 +46,20 @@ func (s *Schema) Migrate(ctx context.Context) (err error) {
 	if s.options.Overrides.MigrateDSN != "" && len(todo) > 1 {
 		return errors.Errorf("--migrate-dsn can only be used when there is only one database to migrate")
 	}
+	if s.options.Overrides.NoMigrate {
+		return nil
+	}
 	for _, d := range todo {
 		if len(d.errors) != 0 {
-			return multierror.Append(d.errors[0], d.errors[1:]...)
+			err := errors.Join(d.errors...)
+			d.allDone(nil, err)
+			return err
 		}
 		err := func(d *Database) (finalErr error) {
+			var m Migration
+			defer func() {
+				d.allDone(m, finalErr)
+			}()
 			if s.options.Overrides.MigrateDSN != "" {
 				var err error
 				d.db, err = OpenAnyDB(s.options.Overrides.MigrateDSN)
@@ -61,7 +72,7 @@ func (s *Schema) Migrate(ctx context.Context) (err error) {
 				return err
 			}
 			defer func() {
-				err := d.unlock()
+				err := d.unlock(false)
 				if err != nil && finalErr == nil {
 					finalErr = err
 				}
@@ -69,7 +80,8 @@ func (s *Schema) Migrate(ctx context.Context) (err error) {
 			if s.options.Overrides.ErrorIfMigrateNeeded && !d.done(s) {
 				return errors.Errorf("migrations required for %s", d.DBName)
 			}
-			return d.migrate(ctx, s)
+			m, err = d.migrate(ctx, s)
+			return err
 		}(d)
 		if err != nil {
 			return err
@@ -154,22 +166,16 @@ func (d *Database) done(s *Schema) bool {
 	return true
 }
 
-func (d *Database) migrate(ctx context.Context, s *Schema) (err error) {
+func (d *Database) migrate(ctx context.Context, s *Schema) (lastMigration Migration, err error) {
 	if d.Options.ErrorOnUnknownMigrations && len(d.unknownMigrations) > 0 {
-		return errors.Errorf("%d unknown migrations, including %s", len(d.unknownMigrations), d.unknownMigrations[0])
+		return nil, errors.Errorf("%d unknown migrations, including %s", len(d.unknownMigrations), d.unknownMigrations[0])
 	}
-
-	defer func() {
-		if !d.asyncInProgress {
-			d.allDone(nil, err)
-		}
-	}()
 
 	if d.done(s) {
 		d.log.Info("No migrations needed", map[string]interface{}{
 			"database": d.DBName,
 		})
-		return nil
+		return nil, nil
 	}
 
 	if d.Options.OnMigrationsStarted != nil {
@@ -203,10 +209,10 @@ func (d *Database) migrate(ctx context.Context, s *Schema) (err error) {
 				"name":     m.Base().Name.Name,
 			})
 			if !s.options.Overrides.MigrateOnly {
-				d.asyncInProgress = true
+				d.asyncInProgress.Store(true)
 				go d.asyncMigrate(ctx)
 			}
-			return nil
+			return m, nil
 		}
 		var stop bool
 		stop, err = d.doOneMigration(ctx, m)
@@ -216,10 +222,10 @@ func (d *Database) migrate(ctx context.Context, s *Schema) (err error) {
 			syncExecuted = append(syncExecuted, m)
 		}
 		if err != nil || stop {
-			return err
+			return m, err
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func (d *Database) reportSequenceError(migrations []Migration, err error, syncOrAsync string) {
@@ -375,8 +381,19 @@ func (d *Database) lastUnfinishedSynchrnous() int {
 
 // allDone reports status
 func (d *Database) allDone(m Migration, err error) {
+	if d.asyncInProgress.Load() {
+		// so that allDone can be called in defer
+		return
+	}
+	// only report complete at most once
+	if d.allDoneDone.Add(1) != 1 {
+		return
+	}
 	if d.Options.OnMigrationsComplete != nil {
 		d.Options.OnMigrationsComplete(d, err)
+	}
+	if d.Options.CloseOnComplete {
+		_ = d.db.Close()
 	}
 	if err != nil {
 		logInfo := map[string]any{
@@ -400,12 +417,14 @@ func (d *Database) asyncMigrate(ctx context.Context) {
 	var m Migration
 	d.log.Info("Starting async migrations")
 	defer func() {
-		d.asyncInProgress = false
-		e := d.unlock()
+		defer func() {
+			d.asyncInProgress.Store(false)
+			d.allDone(m, err)
+		}()
+		e := d.unlock(true)
 		if err == nil {
 			err = e
 		}
-		d.allDone(m, err)
 		d.log.Info("Done with async migrations")
 	}()
 	var i int
@@ -424,8 +443,9 @@ func (d *Database) asyncMigrate(ctx context.Context) {
 	}
 }
 
-func (d *Database) unlock() error {
-	if !d.asyncInProgress {
+// force is used so that asyncInProgress can be cleared only after unlocking is complete.
+func (d *Database) unlock(force bool) error {
+	if force || !d.asyncInProgress.Load() {
 		if d.migrationsLocked {
 			err := d.driver.UnlockMigrationsTable(d.log)
 			if err != nil {

--- a/config.go
+++ b/config.go
@@ -12,9 +12,13 @@ type OverrideOptions struct {
 
 	// MigrateDatabase specifies that only a specific database should
 	// be migrated.  The name must match to a name provided with the schema.NewDatabase() call.
-	// For both libschema/lsmysql and libschema/lspostgres, that is the name parameter to
-	// New() NOT the database name in the DSN.  This is a logical name.
-	MigrateDatabase string `flag:"migrate-database" help:"Migrate only the this database"`
+	// For libschema/lsmysql, libschema/lspostgres and libschema/lssinglestore, that is the
+	// name parameter to New() NOT the database name in the DSN.  This is a logical name.
+	//
+	// MigrateDatabase narrows the scope of which databases migrate but OnMigrationsComplete and
+	// CloseOnComplete still apply to all databases. OnMigrationsStarted only
+	// applies to databases that are being migrated.
+	MigrateDatabase string `flag:"migrate-database" help:"Migrate only this database"`
 
 	// MigrateDSN overrides the data source name for a single database.  It must be used in
 	// conjunction with MigrateDatabase unless there are only migrations for a single database.

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,11 @@
 module github.com/muir/libschema
 
-go 1.21.0
+go 1.22.0
 
 toolchain go1.24.2
 
 require (
 	github.com/go-sql-driver/mysql v1.9.3
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/lib/pq v1.12.3
 	github.com/memsql/errors v0.2.0
 	github.com/muir/sqltoken v0.5.1
@@ -18,7 +17,6 @@ require (
 require (
 	filippo.io/edwards25519 v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/muir/list v1.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,6 @@ github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/lsmysql/mysql.go
+++ b/lsmysql/mysql.go
@@ -103,7 +103,7 @@ func New(log *internal.Log, dbName string, schema *libschema.Schema, db *sql.DB,
 // migrations set the SchemaOverride option.
 //
 // It is the caller's responsibility to eventually call either database.DB().Close()
-// or mysql.DB().Close()
+// or mysql.DB().Close(). The simple way to do that is to set the CloseOnComplete option.
 func NewWithOpener(log *internal.Log, dbName string, schema *libschema.Schema, opener func() (*sql.DB, error), options ...MySQLOpt) (*libschema.Database, *MySQL, error) {
 	return newMaybeWithOpener(log, dbName, schema, nil, opener, options...)
 }

--- a/lspostgres/async_test.go
+++ b/lspostgres/async_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/memsql/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -29,7 +30,6 @@ func TestAsyncMigrations(t *testing.T) {
 	options.ErrorOnUnknownMigrations = true
 	options.OnMigrationsComplete = func(_ *libschema.Database, err error) {
 		assert.NoError(t, err, "completion error")
-		time.Sleep(10 * time.Millisecond)
 		close(migrationComplete)
 		t.Log("All migrations are complete (signaled)")
 	}
@@ -82,7 +82,6 @@ func TestAsyncMigrations(t *testing.T) {
 	err = s.Migrate(context.Background())
 	assert.NoError(t, err)
 	t.Log("Synchronous migrations complete")
-	time.Sleep(10 * time.Millisecond)
 	t.Log("Signalling that the migrate command returned")
 	close(migrateReturned)
 
@@ -105,4 +104,134 @@ func TestAsyncMigrations(t *testing.T) {
 	}
 	nt.Stop()
 	t.Log("All done!")
+}
+
+func TestAsyncMigrationsKeepLockUntilDone(t *testing.T) {
+	dsn := os.Getenv("LIBSCHEMA_POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("Set $LIBSCHEMA_POSTGRES_TEST_DSN to test libschema/lspostgres")
+	}
+
+	ctx := context.Background()
+	options, cleanup := lstesting.FakeSchema(t, "CASCADE")
+
+	db1, err := sql.Open("postgres", dsn)
+	require.NoError(t, err, "open first database")
+	defer func() {
+		t.Log("Closing db1...")
+		_ = db1.Close()
+		t.Log("done")
+	}()
+	defer func() {
+		t.Log("Doing cleanup...")
+		cleanup(db1)
+		t.Log("done")
+	}()
+
+	db2, err := sql.Open("postgres", dsn)
+	require.NoError(t, err, "open second database")
+	defer func() {
+		t.Log("Closing db2...")
+		_ = db2.Close()
+		t.Log("done")
+	}()
+
+	asyncStarted := make(chan struct{})
+	releaseAsync := make(chan struct{})
+	firstComplete := make(chan struct{})
+
+	options1 := options
+	options1.OnMigrationsComplete = func(_ *libschema.Database, err error) {
+		assert.NoError(t, err)
+		close(firstComplete)
+	}
+
+	s1 := libschema.New(ctx, options1)
+	dbase1, err := lspostgres.New(libschema.LogFromLog(t), "test", s1, db1)
+	require.NoError(t, err)
+	dbase1.Migrations("L1",
+		lspostgres.Generate("M1", func(_ context.Context, _ *sql.Tx) string {
+			return `CREATE TABLE m1_locktest (id text)`
+		}),
+		lspostgres.Computed("M2", func(_ context.Context, _ *sql.Tx) error {
+			close(asyncStarted)
+			nt := time.NewTimer(time.Second)
+			defer nt.Stop()
+			select {
+			case <-releaseAsync:
+				return nil
+			case <-nt.C:
+				return errors.Errorf("timeout waiting to release async migration")
+			}
+		}, libschema.Asynchronous()),
+	)
+
+	migrateCtx1, cancel1 := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel1()
+	require.NoError(t, s1.Migrate(migrateCtx1), "first migrate should return after synchronous work")
+	ntStart := time.NewTimer(time.Second)
+	defer ntStart.Stop()
+	select {
+	case <-asyncStarted:
+	case <-ntStart.C:
+		assert.FailNow(t, "timeout waiting for async start", "async migration did not start")
+	}
+
+	startedSecond := make(chan struct{})
+	options2 := options
+	// Reaching OnMigrationsStarted means the second migrator acquired the table lock.
+	options2.OnMigrationsStarted = func(_ *libschema.Database) {
+		close(startedSecond)
+	}
+
+	s2 := libschema.New(ctx, options2)
+	dbase2, err := lspostgres.New(libschema.LogFromLog(t), "test", s2, db2)
+	require.NoError(t, err)
+	dbase2.Migrations("L2",
+		lspostgres.Computed("M3", func(_ context.Context, _ *sql.Tx) error {
+			return nil
+		}),
+	)
+
+	secondDone := make(chan error, 1)
+	migrateCtx2, cancel2 := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel2()
+	secondAttempted := make(chan struct{})
+	go func() {
+		close(secondAttempted)
+		secondDone <- s2.Migrate(migrateCtx2)
+	}()
+
+	ntAttempt := time.NewTimer(time.Second)
+	defer ntAttempt.Stop()
+	select {
+	case <-secondAttempted:
+	case <-ntAttempt.C:
+		assert.FailNow(t, "timeout waiting for second migrate attempt", "second migrate was not started")
+	}
+
+	select {
+	case <-startedSecond:
+		assert.FailNow(t, "second migrate started too early", "migration table lock released before async migration completed")
+	default:
+	}
+
+	close(releaseAsync)
+
+	nt := time.NewTimer(time.Second)
+	defer nt.Stop()
+	select {
+	case <-firstComplete:
+	case <-nt.C:
+		assert.FailNow(t, "timeout waiting for first completion", "first migration sequence did not complete")
+	}
+
+	nt2 := time.NewTimer(time.Second)
+	defer nt2.Stop()
+	select {
+	case err := <-secondDone:
+		require.NoError(t, err, "second migrate should proceed once first async migration has completed")
+	case <-nt2.C:
+		assert.FailNow(t, "timeout waiting for second migrate", "second migrate did not complete after lock release")
+	}
 }

--- a/lspostgres/config_test.go
+++ b/lspostgres/config_test.go
@@ -40,13 +40,24 @@ func TestOverrideMigrateOnly(t *testing.T) {
 
 func TestOverrideMigrateDatabaseNotMatching(t *testing.T) {
 	t.Parallel()
+	options, cleanup := lstesting.FakeSchema(t, "CASCADE")
+	options.CloseOnComplete = true
 	var code string
-	_, err := doConfigMigrate(t, nil, getDSN(t), false, &code, nil, &libschema.OverrideOptions{
+	dsn := getDSN(t)
+	db, err := doConfigMigrate(t, &options, dsn, true, &code, nil, &libschema.OverrideOptions{
 		MigrateDatabase: "notmatching",
 	})
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "migrate: database 'notmatching'")
 	}
+	assert.Error(t, db.Ping())
+	if assert.NotNil(t, db) {
+		_ = db.Close()
+	}
+	db, err = sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	cleanup(db)
+	assert.NoError(t, db.Close())
 	assert.Equal(t, "", code)
 }
 
@@ -107,6 +118,42 @@ func TestOverrideNoMigrate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "", code)
 	assert.Equal(t, "", code2)
+}
+
+func TestOverrideMigrateCloseOnCompleteNoMigrate(t *testing.T) {
+	t.Parallel()
+	options, cleanup := lstesting.FakeSchema(t, "CASCADE")
+	options.CloseOnComplete = true
+	var code string
+	dsn := getDSN(t)
+	db, err := doConfigMigrate(t, &options, dsn, false, &code, nil, &libschema.OverrideOptions{
+		NoMigrate: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "", code)
+	assert.Eventually(t, func() bool { return db.Ping() != nil }, time.Second, time.Millisecond*4)
+	_ = db.Close()
+	db, err = sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	cleanup(db)
+	assert.NoError(t, db.Close())
+}
+
+func TestOverrideMigrateCloseOnCompleteAsync(t *testing.T) {
+	t.Parallel()
+	options, cleanup := lstesting.FakeSchema(t, "CASCADE")
+	options.CloseOnComplete = true
+	var code string
+	dsn := getDSN(t)
+	db, err := doConfigMigrate(t, &options, dsn, true, &code, nil, &libschema.OverrideOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "m2async", code)
+	assert.Eventually(t, func() bool { return db.Ping() != nil }, time.Second, time.Millisecond*4)
+	_ = db.Close()
+	db, err = sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	cleanup(db)
+	assert.NoError(t, db.Close())
 }
 
 func TestOverrideErrorIfMigrateNeeded(t *testing.T) {

--- a/lspostgres/postgres.go
+++ b/lspostgres/postgres.go
@@ -44,7 +44,8 @@ func New(log *internal.Log, dbName string, schema *libschema.Schema, db *sql.DB)
 // parameter is used internally by libschema, but does not affect where migrations
 // are actually applied.
 //
-// It is the caller's responsibility to eventually call database.DB().Close()
+// It is the caller's responsibility to eventually call database.DB().Close().
+// The simple way to do that is to set the CloseOnComplete option.
 func NewWithOpener(log *internal.Log, dbName string, schema *libschema.Schema, opener func() (*sql.DB, error)) (*libschema.Database, error) {
 	return schema.NewDatabaseWithOpener(log, dbName, opener, &Postgres{log: log})
 }

--- a/lssinglestore/singlestore.go
+++ b/lssinglestore/singlestore.go
@@ -50,7 +50,7 @@ func New(log *internal.Log, dbName string, schema *libschema.Schema, db *sql.DB)
 // NewWithOpener creates a libschema.Database with a Singlestore driver built in.
 //
 // It is the caller's responsibility to eventually call either database.DB().Close()
-// or singlestore.DB().Close()
+// or singlestore.DB().Close(). The simple way to do that is to set the CloseOnComplete option.
 func NewWithOpener(log *internal.Log, dbName string, schema *libschema.Schema, opener func() (*sql.DB, error)) (*libschema.Database, *SingleStore, error) {
 	return newMaybeWithOpener(log, dbName, schema, nil, opener)
 }


### PR DESCRIPTION
Adds a `CloseOnComplete` configuration variable that closes the database when the migration is complete.

Change of behavior: `OnMigrationComplete` didn't used to be called if migrations were skipped. If migrations only touched some databases, it wasn't called on the ones that were not touched. It is now always called on all databases.

Also: minimum go version now 1.22